### PR TITLE
Support referred vars in CLJS by parsing the `(ns)` form

### DIFF
--- a/autoload/mantel.vim
+++ b/autoload/mantel.vim
@@ -33,5 +33,7 @@ func! mantel#Highlight()
     if s:hasNsRefers(bufnr)
         " use ns-refers to fetch referred vars
         call mantel#refers#Fetch(bufnr, ns)
+    else
+        call mantel#ns#ParseReferred(bufnr, ns)
     endif
 endfunc

--- a/autoload/mantel/async.vim
+++ b/autoload/mantel/async.vim
@@ -1,3 +1,29 @@
+
+func! s:ApplyPendingSyntax(bufnr)
+    " due to the way the syntax_keywords map is applied, we cannot allow
+    " empty lists
+    let pendingSyntax = getbufvar(a:bufnr, 'mantel_pendingSyntax', {})
+    for key in keys(pendingSyntax)
+        if empty(pendingSyntax[key])
+            unlet pendingSyntax[key]
+        endif
+    endfor
+
+    " we can only get the core keywords (eg: macros like `and`) via ns-refers
+    " TODO setting this to 1 also disables default highlighting for things
+    " like `throw`, `new`, `case`, etc.
+    let hasCoreKeywords = 0 " TODO s:hasNsRefers(a:bufnr)
+
+    " apply results
+    call setbufvar(a:bufnr, 'clojure_syntax_keywords', pendingSyntax)
+    call setbufvar(a:bufnr, 'clojure_syntax_without_core_keywords', hasCoreKeywords)
+    call setbufvar(a:bufnr, '&syntax',
+        \ getbufvar(a:bufnr, '&syntax', 'clojure'))
+endfunc
+
+
+" ======= Public interface ================================
+
 func! mantel#async#AdjustPendingRequests(bufnr, delta)
     let oldCount = getbufvar(a:bufnr, 'mantel_pendingRequests', -1)
     if oldCount < 0
@@ -6,6 +32,11 @@ func! mantel#async#AdjustPendingRequests(bufnr, delta)
 
     let newCount = oldCount + a:delta
     call setbufvar(a:bufnr, 'mantel_pendingRequests', newCount)
+
+    if a:delta < 0 && newCount == 0
+        " apply all changes at once to avoid flicker
+        call s:ApplyPendingSyntax(a:bufnr)
+    endif
 
     return newCount
 endfunc

--- a/autoload/mantel/async.vim
+++ b/autoload/mantel/async.vim
@@ -6,6 +6,8 @@ func! mantel#async#AdjustPendingRequests(bufnr, delta)
 
     let newCount = oldCount + a:delta
     call setbufvar(a:bufnr, 'mantel_pendingRequests', newCount)
+
+    return newCount
 endfunc
 
 func! mantel#async#ConcatSyntaxKeys(bufnr, kind, keys)

--- a/autoload/mantel/async.vim
+++ b/autoload/mantel/async.vim
@@ -7,3 +7,12 @@ func! mantel#async#AdjustPendingRequests(bufnr, delta)
     let newCount = oldCount + a:delta
     call setbufvar(a:bufnr, 'mantel_pendingRequests', newCount)
 endfunc
+
+func! mantel#async#ConcatSyntaxKeys(bufnr, kind, keys)
+    let pendingSyntax = getbufvar(a:bufnr, 'mantel_pendingSyntax', {})
+    if has_key(pendingSyntax, a:kind)
+        let pendingSyntax[a:kind] = pendingSyntax[a:kind] + a:keys
+    else
+        let pendingSyntax[a:kind] = a:keys
+    endif
+endfunc

--- a/autoload/mantel/ns.vim
+++ b/autoload/mantel/ns.vim
@@ -1,0 +1,67 @@
+
+" ======= constants =======================================
+
+let s:maxNsLines = 100
+
+
+" ======= Callbacks =======================================
+
+func! s:onNsEval(bufnr, resp)
+    if has_key(a:resp, 'err')
+        echom 'ERROR' . string(a:resp)
+        return
+    elseif !has_key(a:resp, 'value')
+        return
+    endif
+
+    echom a:resp
+
+    call mantel#async#AdjustPendingRequests(a:bufnr, -1)
+endfunc
+
+func! s:onPath(bufnr, resp)
+    if !has_key(a:resp, 'path')
+        return
+    endif
+
+    let path = a:resp.path
+    echom "got path: " . path
+    let contents = join(readfile(path, '', s:maxNsLines), '\n')
+    let readerNs = 'clojure.edn'
+    if matchstr(path, '.cljs$') !=# ''
+        let readerNs = 'cljs.reader'
+    endif
+
+    " TODO 
+    let request = '(let [ns-form (->> "' . escape(contents, '"') . '"'
+              \ . '                   (' . readerNs . '/read-string))'
+              \ . '      macros (filter'
+              \ . '               #(and (seq? %)'
+              \ . '                     (= :require-macros (first %)))'
+              \ . '               ns-form)'
+              \ . '      refers (filter'
+              \ . '               #(and (seq? %)'
+              \ . '                     (= :require (first %)))'
+              \ . '               ns-form)]'
+              \ . '  refers)'
+    echom "request: " . request
+    call fireplace#message({
+        \ 'op': 'eval',
+        \ 'code': request,
+        \ }, function('s:onNsEval', [a:bufnr]))
+endfunc
+
+
+" ======= Public interface ================================
+
+func! mantel#ns#ParseReferred(bufnr, ns)
+    " Parse the (ns) form for the given ns and extract :refer'd vars.
+    " This is for situations where ns-refers isn't available, and is
+    " likely a *terrible* idea.
+
+    call mantel#async#AdjustPendingRequests(a:bufnr, 1)
+    call fireplace#message({
+        \ 'op': 'ns-path',
+        \ 'ns': a:ns,
+        \ }, function('s:onPath', [a:bufnr]))
+endfunc


### PR DESCRIPTION
Clojurescript doesn't have `(ns-refers)` so this seems like the only approach. It doesn't cover every case, but it works pretty well and seems like a worthwhile addition. It is a bit slower than ns-refers, but that's not surprising—and it's async anyway, so it shouldn't slow us down. 

It may be okay to apply this step incrementally, instead of being part of the all-at-once approach we do to combine the other methods, but that sounds like future optimization work that doesn't belong in this PR.